### PR TITLE
Support to mount outer volume

### DIFF
--- a/Dockerfile/mysql5623_mroonga410/Dockerfile
+++ b/Dockerfile/mysql5623_mroonga410/Dockerfile
@@ -9,6 +9,8 @@ RUN yum install --enablerepo=mysql56-community --disablerepo=mysql57-community -
 RUN yum install -y mysql-community-mroonga-4.10 groonga-4.1.1 groonga-tokenizer-mecab-4.1.1
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION" && mysql < /usr/share/mroonga/install.sql
+RUN rpm -q --scripts mysql-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306
-ENTRYPOINT /usr/sbin/mysqld --user=mysql
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/Dockerfile/mysql5623_mroonga410/entrypoint.sh
+++ b/Dockerfile/mysql5623_mroonga410/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ ! -e /var/lib/mysql/ibdata1 ] ; then
+  chown -R mysql. /var/lib/mysql
+  service mysqld start && bash /root/postinstall.sh && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION" && service mysqld stop
+fi
+
+oldowner=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $3}')
+oldgroup=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $4}')
+
+chown -R mysql. /var/lib/mysql
+/usr/sbin/mysqld --user=mysql "$@"
+
+chown -R $oldowner.$oldgroup /var/lib/mysql

--- a/Dockerfile/mysql5626_mroonga506/Dockerfile
+++ b/Dockerfile/mysql5626_mroonga506/Dockerfile
@@ -9,6 +9,8 @@ RUN yum install --enablerepo=mysql56-community --disablerepo=mysql57-community -
 RUN yum install -y mysql-community-mroonga-5.06 groonga-5.0.6 groonga-tokenizer-mecab-5.0.6
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION"
+RUN rpm -q --scripts mysql-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306
-ENTRYPOINT /usr/sbin/mysqld --user=mysql
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/Dockerfile/mysql5626_mroonga506/entrypoint.sh
+++ b/Dockerfile/mysql5626_mroonga506/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -e /var/lib/mysql/ibdata1 ] ; then
+  chown -R mysql. /var/lib/mysql
+  bash /root/postinstall.sh
+  service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION" && service mysqld stop
+fi
+
+oldowner=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $3}')
+oldgroup=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $4}')
+
+chown -R mysql. /var/lib/mysql
+/usr/sbin/mysqld --user=mysql "$@"
+
+chown -R $oldowner.$oldgroup /var/lib/mysql

--- a/Dockerfile/mysql5627_mroonga508/Dockerfile
+++ b/Dockerfile/mysql5627_mroonga508/Dockerfile
@@ -9,6 +9,8 @@ RUN yum install --enablerepo=mysql56-community --disablerepo=mysql57-community -
 RUN yum install -y mysql-community-mroonga-5.08 groonga-5.0.8 groonga-tokenizer-mecab-5.0.8
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION"
+RUN rpm -q --scripts mysql-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306
-ENTRYPOINT /usr/sbin/mysqld --user=mysql
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/Dockerfile/mysql5627_mroonga508/entrypoint.sh
+++ b/Dockerfile/mysql5627_mroonga508/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -e /var/lib/mysql/ibdata1 ] ; then
+  chown -R mysql. /var/lib/mysql
+  bash /root/postinstall.sh
+  service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION" && service mysqld stop
+fi
+
+oldowner=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $3}')
+oldgroup=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $4}')
+
+chown -R mysql. /var/lib/mysql
+/usr/sbin/mysqld --user=mysql "$@"
+
+chown -R $oldowner.$oldgroup /var/lib/mysql

--- a/Dockerfile/mysql5627_mroonga509/Dockerfile
+++ b/Dockerfile/mysql5627_mroonga509/Dockerfile
@@ -9,6 +9,8 @@ RUN yum install --enablerepo=mysql56-community --disablerepo=mysql57-community -
 RUN yum install -y mysql-community-mroonga-5.09 groonga-5.0.9 groonga-tokenizer-mecab-5.0.9
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION"
+RUN rpm -q --scripts mysql-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306
-ENTRYPOINT /usr/sbin/mysqld --user=mysql
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/Dockerfile/mysql5627_mroonga509/entrypoint.sh
+++ b/Dockerfile/mysql5627_mroonga509/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -e /var/lib/mysql/ibdata1 ] ; then
+  chown -R mysql. /var/lib/mysql
+  bash /root/postinstall.sh
+  service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION" && service mysqld stop
+fi
+
+oldowner=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $3}')
+oldgroup=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $4}')
+
+chown -R mysql. /var/lib/mysql
+/usr/sbin/mysqld --user=mysql "$@"
+
+chown -R $oldowner.$oldgroup /var/lib/mysql

--- a/Dockerfile/mysql5627_mroonga510/Dockerfile
+++ b/Dockerfile/mysql5627_mroonga510/Dockerfile
@@ -9,6 +9,8 @@ RUN yum install --enablerepo=mysql56-community --disablerepo=mysql57-community -
 RUN yum install -y mysql-community-mroonga-5.10 groonga-5.1.0 groonga-tokenizer-mecab-5.1.0
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION"
+RUN rpm -q --scripts mysql-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306
-ENTRYPOINT /usr/sbin/mysqld --user=mysql
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/Dockerfile/mysql5627_mroonga510/entrypoint.sh
+++ b/Dockerfile/mysql5627_mroonga510/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -e /var/lib/mysql/ibdata1 ] ; then
+  chown -R mysql. /var/lib/mysql
+  bash /root/postinstall.sh
+  service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION" && service mysqld stop
+fi
+
+oldowner=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $3}')
+oldgroup=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $4}')
+
+chown -R mysql. /var/lib/mysql
+/usr/sbin/mysqld --user=mysql "$@"
+
+chown -R $oldowner.$oldgroup /var/lib/mysql

--- a/Dockerfile/mysql579_mroonga509/Dockerfile
+++ b/Dockerfile/mysql579_mroonga509/Dockerfile
@@ -10,6 +10,8 @@ RUN yum install -y mysql57-community-mroonga-5.09 groonga-5.0.9 groonga-tokenize
 RUN awk '/root@localhost/{print $NF}' /var/log/mysqld.log > /root/mysql_password
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -p$(cat /root/mysql_password) --connect-expired-password -e "ALTER USER user() IDENTIFIED BY ''; CREATE USER root@'%'; GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION"
+RUN rpm -q --scripts mysql57-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306
-ENTRYPOINT /usr/sbin/mysqld --user=mysql
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/Dockerfile/mysql579_mroonga509/entrypoint.sh
+++ b/Dockerfile/mysql579_mroonga509/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ ! -e /var/lib/mysql/ibdata1 ] ; then
+  chown -R mysql. /var/lib/mysql
+  rm /var/log/mysqld.log
+  bash /root/postinstall.sh
+  awk '/root@localhost/{print $NF}' /var/log/mysqld.log > /root/mysql_password
+  service mysqld start && mysql -p$(cat /root/mysql_password) --connect-expired-password -e "ALTER USER user() IDENTIFIED BY ''; CREATE USER root@'%'; GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION" && service mysqld stop
+fi
+
+oldowner=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $3}')
+oldgroup=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $4}')
+
+chown -R mysql. /var/lib/mysql
+/usr/sbin/mysqld --user=mysql "$@"
+
+chown -R $oldowner.$oldgroup /var/lib/mysql

--- a/Dockerfile/mysql579_mroonga509/my.cnf
+++ b/Dockerfile/mysql579_mroonga509/my.cnf
@@ -28,4 +28,4 @@ pid-file=/var/run/mysqld/mysqld.pid
 
 ### Added by yoku0825
 character_set_server= utf8mb4
-validate_password   = OFF
+loose-validate_password   = OFF

--- a/Dockerfile/mysql579_mroonga510/Dockerfile
+++ b/Dockerfile/mysql579_mroonga510/Dockerfile
@@ -10,6 +10,8 @@ RUN yum install -y mysql57-community-mroonga-5.10 groonga-5.1.0 groonga-tokenize
 RUN awk '/root@localhost/{print $NF}' /var/log/mysqld.log > /root/mysql_password
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -p$(cat /root/mysql_password) --connect-expired-password -e "ALTER USER user() IDENTIFIED BY ''; CREATE USER root@'%'; GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION"
+RUN rpm -q --scripts mysql57-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306
-ENTRYPOINT /usr/sbin/mysqld --user=mysql
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/Dockerfile/mysql579_mroonga510/entrypoint.sh
+++ b/Dockerfile/mysql579_mroonga510/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ ! -e /var/lib/mysql/ibdata1 ] ; then
+  chown -R mysql. /var/lib/mysql
+  rm /var/log/mysqld.log
+  bash /root/postinstall.sh
+  awk '/root@localhost/{print $NF}' /var/log/mysqld.log > /root/mysql_password
+  service mysqld start && mysql -p$(cat /root/mysql_password) --connect-expired-password -e "ALTER USER user() IDENTIFIED BY ''; CREATE USER root@'%'; GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION" && service mysqld stop
+fi
+
+oldowner=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $3}')
+oldgroup=$(ls -ln /var/lib/mysql/ibdata1 | awk '{print $4}')
+
+chown -R mysql. /var/lib/mysql
+/usr/sbin/mysqld --user=mysql "$@"
+
+chown -R $oldowner.$oldgroup /var/lib/mysql

--- a/Dockerfile/mysql579_mroonga510/my.cnf
+++ b/Dockerfile/mysql579_mroonga510/my.cnf
@@ -28,4 +28,4 @@ pid-file=/var/run/mysqld/mysqld.pid
 
 ### Added by yoku0825
 character_set_server= utf8mb4
-validate_password   = OFF
+loose-validate_password   = OFF


### PR DESCRIPTION
Implement for #9 

When using `-v` option like

```
$ sudo docker run -d -v $PWD/data:/var/lib/mysql groonga/mroonga
```

1, Container searches /var/lib/mysql/ibdata1.
1. If ibdata1 is already there, container just starts with mounted datadir.
1. If ibdata1 isn't there, container will re-initialize (execute mysql-community-mroonga's post-install scriptlet) for new data directory.