### PR TITLE
Remove variable files which was created at building image

### DIFF
--- a/Dockerfile/mysql5623_mroonga410/Dockerfile
+++ b/Dockerfile/mysql5623_mroonga410/Dockerfile
@@ -10,6 +10,7 @@ RUN yum install -y mysql-community-mroonga-4.10 groonga-4.1.1 groonga-tokenizer-
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION" && mysql < /usr/share/mroonga/install.sql
 RUN rpm -q --scripts mysql-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+RUN rm /var/lib/mysql/auto.cnf /var/lib/mysql/groonga.log
 COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306

--- a/Dockerfile/mysql5626_mroonga506/Dockerfile
+++ b/Dockerfile/mysql5626_mroonga506/Dockerfile
@@ -10,6 +10,7 @@ RUN yum install -y mysql-community-mroonga-5.06 groonga-5.0.6 groonga-tokenizer-
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION"
 RUN rpm -q --scripts mysql-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+RUN rm /var/lib/mysql/auto.cnf /var/lib/mysql/groonga.log
 COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306

--- a/Dockerfile/mysql5627_mroonga508/Dockerfile
+++ b/Dockerfile/mysql5627_mroonga508/Dockerfile
@@ -10,6 +10,7 @@ RUN yum install -y mysql-community-mroonga-5.08 groonga-5.0.8 groonga-tokenizer-
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION"
 RUN rpm -q --scripts mysql-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+RUN rm /var/lib/mysql/auto.cnf /var/lib/mysql/groonga.log
 COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306

--- a/Dockerfile/mysql5627_mroonga509/Dockerfile
+++ b/Dockerfile/mysql5627_mroonga509/Dockerfile
@@ -10,6 +10,7 @@ RUN yum install -y mysql-community-mroonga-5.09 groonga-5.0.9 groonga-tokenizer-
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION"
 RUN rpm -q --scripts mysql-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+RUN rm /var/lib/mysql/auto.cnf /var/lib/mysql/groonga.log
 COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306

--- a/Dockerfile/mysql5627_mroonga510/Dockerfile
+++ b/Dockerfile/mysql5627_mroonga510/Dockerfile
@@ -10,6 +10,7 @@ RUN yum install -y mysql-community-mroonga-5.10 groonga-5.1.0 groonga-tokenizer-
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -e "GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION"
 RUN rpm -q --scripts mysql-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+RUN rm /var/lib/mysql/auto.cnf /var/lib/mysql/groonga.log
 COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306

--- a/Dockerfile/mysql579_mroonga509/Dockerfile
+++ b/Dockerfile/mysql579_mroonga509/Dockerfile
@@ -11,6 +11,7 @@ RUN awk '/root@localhost/{print $NF}' /var/log/mysqld.log > /root/mysql_password
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -p$(cat /root/mysql_password) --connect-expired-password -e "ALTER USER user() IDENTIFIED BY ''; CREATE USER root@'%'; GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION"
 RUN rpm -q --scripts mysql57-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+RUN rm /var/lib/mysql/auto.cnf /var/lib/mysql/groonga.log
 COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306

--- a/Dockerfile/mysql579_mroonga510/Dockerfile
+++ b/Dockerfile/mysql579_mroonga510/Dockerfile
@@ -11,6 +11,7 @@ RUN awk '/root@localhost/{print $NF}' /var/log/mysqld.log > /root/mysql_password
 COPY my.cnf /etc/my.cnf
 RUN service mysqld start && mysql -p$(cat /root/mysql_password) --connect-expired-password -e "ALTER USER user() IDENTIFIED BY ''; CREATE USER root@'%'; GRANT ALL ON *.* TO root@'%' WITH GRANT OPTION"
 RUN rpm -q --scripts mysql57-community-mroonga | sed -n '/^postinstall scriptlet/,/^[a-z][a-z]* scriptlet/p' | tail -n +2 | head -n -1 > /root/postinstall.sh
+RUN rm /var/lib/mysql/auto.cnf /var/lib/mysql/groonga.log
 COPY entrypoint.sh /root/entrypoint.sh
 
 EXPOSE 3306


### PR DESCRIPTION
Container should remove auto.cnf and groonga.log which was created at building image.