### PR TITLE
Add `--prepare` option for parallel `docker build`

### DIFF
--- a/test/cpanfile
+++ b/test/cpanfile
@@ -2,3 +2,4 @@ requires "DBD::mysql";
 requires "Test::More";
 requires "Test::More::Color";
 requires "JSON";
+requires "Parallel::ForkManager";


### PR DESCRIPTION
Preparing docker images (no-drop-cache) in parallel makes fast all tag's test!