### PR TITLE
Add support for customizing by /etc/my.cnf.d/

### DIFF
--- a/Dockerfile/mysql5725_mroonga900/my.cnf
+++ b/Dockerfile/mysql5725_mroonga900/my.cnf
@@ -29,3 +29,5 @@ pid-file=/var/run/mysqld/mysqld.pid
 ### Added by yoku0825
 character_set_server= utf8mb4
 loose-validate_password   = OFF
+
+!includedir /etc/my.cnf.d/


### PR DESCRIPTION
For example:

    % cat /tmp/mroonga/my.cnf.d/local.cnf
    [mysqld]
    max_allowed_packet = 1G
    % docker run --rm -p 3306:3306 $/tmp/mroonga/my.cnf.d:/etc/my.cnf.d groonga/mroonga:latest
    mysql> show variables like 'max_allowed_packet';
    +--------------------+------------+
    | Variable_name      | Value      |
    +--------------------+------------+
    | max_allowed_packet | 1073741824 |
    +--------------------+------------+
    1 row in set (0.00 sec)