### PR TITLE
MySQL 5.7.35 and Mroonga 11.06

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Currently, groonga/mroonga provides these couples of versions.
 
 | tag                      | MySQL  | Mroonga | Groonga |
 |--------------------------|--------|---------|---------|
-| mysql-5.7-latest, latest | 5.7.34 | 11.03   | 11.0.3  |
+| mysql-5.7-latest, latest | 5.7.35 | 11.06   | 11.0.6  |
+| mysql-5.7.35-11.06       | 5.7.35 | 11.06   | 11.0.6  |
 | mysql-5.7.34-11.03       | 5.7.34 | 11.03   | 11.0.3  |
 | mysql5734\_mroonga1103   | 5.7.34 | 11.03   | 11.0.3  |
 | mysql5734\_mroonga1102   | 5.7.34 | 11.02   | 11.0.2  |

--- a/mysql-5.7/Dockerfile
+++ b/mysql-5.7/Dockerfile
@@ -1,8 +1,8 @@
-FROM mysql:5.7.34
+FROM mysql:5.7.35
 MAINTAINER groonga
 
-ENV groonga_version=11.0.3 \
-    mroonga_version=11.03
+ENV groonga_version=11.0.6 \
+    mroonga_version=11.06
 
 RUN apt update && \
     apt install -y -V --no-install-recommends \


### PR DESCRIPTION
This is draft PR now.
Because Mroonga 11.06 doesn't release yet.

Fix #71 in this PR.