### PR TITLE
MySQL 8.0.26 and Mroonga 11.06

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Currently, groonga/mroonga provides these couples of versions.
 
 | tag                    | MySQL  | Mroonga | Groonga |
 |------------------------|--------|---------|---------|
-| mysql80-latest         | 8.0.25 | 11.03   | 11.0.3  |
+| mysql80-latest         | 8.0.26 | 11.06   | 11.0.6  |
+| mysql-8.0.26-11.06     | 8.0.26 | 11.06   | 11.0.6  |
 | mysql-8.0.25-11.03     | 8.0.25 | 11.03   | 11.0.3  |
 | mysql8025\_mroonga1103 | 8.0.25 | 11.03   | 11.0.3  |
 | mysql8025\_mroonga1102 | 8.0.25 | 11.02   | 11.0.2  |

--- a/mysql-8.0/Dockerfile
+++ b/mysql-8.0/Dockerfile
@@ -1,8 +1,8 @@
-FROM mysql:8.0.25
+FROM mysql:8.0.26
 MAINTAINER groonga
 
-ENV groonga_version=11.0.3 \
-    mroonga_version=11.03
+ENV groonga_version=11.0.6 \
+    mroonga_version=11.06
 
 RUN mkdir -p /etc/mysql/mysql.conf.d && \
     touch /etc/mysql/mysql.conf.d/default-auth-override.cnf && \


### PR DESCRIPTION
This is draft PR now.
Because Mroonga 11.06 doesn't release yet.

Fix #71 in this PR.