### PR TITLE
mysql-8.0/Dockerfile: Remove `MAINTAINER`

### DIFF
--- a/mysql-8.0/Dockerfile
+++ b/mysql-8.0/Dockerfile
@@ -1,5 +1,4 @@
 FROM mysql:8.0.30-debian
-MAINTAINER groonga
 
 ENV groonga_version=12.0.6 \
     mroonga_version=12.06

--- a/test/build.sh
+++ b/test/build.sh
@@ -19,7 +19,7 @@ container_name="name_${image_name}"
 eval $(grep -E -o '[a-z]+_version=[0-9.]+' ../$context/Dockerfile)
 mysql_version=$(head -n1 ../$context/Dockerfile | grep -E -o '[0-9.]+')
 
-sudo docker build -t $image_name ../$context
+sudo docker --debug build -t $image_name ../$context
 sudo docker run \
   -d \
   -p 33061:3306 \


### PR DESCRIPTION
Removed as deprecated.

```
 1 warning found:
 - MaintainerDeprecated: Maintainer instruction is deprecated in favor of using label (line 2)
The MAINTAINER instruction is deprecated, use a label instead to define an image author
More info: https://docs.docker.com/go/dockerfile/rule/maintainer-deprecated/
Dockerfile:2
--------------------
   1 |     FROM mysql:8.0.30-debian
   2 | >>> MAINTAINER groonga
   3 |
   4 |     ENV groonga_version=12.0.6 \
--------------------
```

We added `--debug` option to docker image build for more information.