### PR TITLE
mysql-8.0/Dockerfile: Update Mroonga and Groonga versions

### DIFF
--- a/mysql-8.0/Dockerfile
+++ b/mysql-8.0/Dockerfile
@@ -23,10 +23,6 @@ RUN mkdir -p /etc/mysql/mysql.conf.d && \
       groonga-tokenizer-mecab=${groonga_version}-1 \
       mysql-community-8.0-mroonga=${mroonga_version}-1 && \
     rm -rf /var/lib/mysql && \
-    sed \
-      -i'' \
-      -e 's,@MRN_DATA_DIR@,/usr/share/mroonga,g' \
-      /usr/share/mroonga/install.sql && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/mysql-8.0/Dockerfile
+++ b/mysql-8.0/Dockerfile
@@ -1,7 +1,7 @@
-FROM mysql:8.0.30-debian
+FROM mysql:8.0.40-debian
 
-ENV groonga_version=12.0.6 \
-    mroonga_version=12.06
+ENV groonga_version=14.1.0 \
+    mroonga_version=14.10
 
 RUN mkdir -p /etc/mysql/mysql.conf.d && \
     touch /etc/mysql/mysql.conf.d/default-auth-override.cnf && \
@@ -22,6 +22,7 @@ RUN mkdir -p /etc/mysql/mysql.conf.d && \
       groonga-normalizer-mysql \
       groonga-tokenizer-mecab=${groonga_version}-1 \
       mysql-community-8.0-mroonga=${mroonga_version}-1 && \
+    rm -rf /var/lib/mysql && \
     sed \
       -i'' \
       -e 's,@MRN_DATA_DIR@,/usr/share/mroonga,g' \
@@ -37,6 +38,6 @@ RUN mkdir -p /docker-entrypoint-mroonga-initdb.d && \
       -e 's,docker_process_init_files /,docker_process_init_files /docker-entrypoint-mroonga-initdb.d/* /,g' \
       /usr/local/bin/docker-entrypoint.sh
 
-# mysql:8.0.30 image has DB in /var/lib/mysql/.
+# mysql:8.0.40 image has DB in /var/lib/mysql/.
 # This clears /var/lib/mysql/ to ensure creating a new DB on "docker run".
 VOLUME ["/var/lib/mysql"]


### PR DESCRIPTION
When mysql-community-8.0-mroonga is installed, mysql-community-server is installed as a dependency.
At that time, the initialization process is also executed, and the initialization process of `docker-entrypoint.sh` is not executed. 
Therefore, `rm -rf /var/lib/mysql` is added.

Removed `sed` since `install.sql` no longer contains `MRN_DATA_DIR`.