### PR TITLE
Get MySQL, Mroonga, and Groonga versions automatically in update.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,7 @@ $ ./test.sh mysql-8.0 mysql80-mroonga
 ## How to release
 
 ```shell
-$ ./update.sh ${MYSQL_VERSION} ${MROONGA_VERSION} ${GROONGA_VERSION}
-(./update.sh 8.0.30 12.06 12.0.6)
+$ ./update.sh
 $ git push
 $ git push --tags
 ```

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -eu
 
 target_mysqls=(
   "8.0"

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-target_mysql-versions=(
+target_mysqls=(
   "8.0"
   "8.4"
 )
@@ -18,15 +18,15 @@ else
   SED=sed
 fi
 
-for target_mysql_version in "${target_mysql-versions[@]}"; do
-  case $target_mysql_version in
+for target_mysql in "${target_mysqls[@]}"; do
+  case $target_mysql in
     8.0)
-      mysql_correct_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
+      mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
                         | jq -r '.["8.0"]["version"]')
       docker_file=mysql-8.0/Dockerfile
       ;;
     8.4)
-      mysql_correct_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
+      mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
                         | jq -r '.["8.4"]["version"]')
       docker_file=mysql-8.4/Dockerfile
       ;;
@@ -35,20 +35,20 @@ for target_mysql_version in "${target_mysql-versions[@]}"; do
   ${SED} \
     -i'' \
     -r \
-    -e "s/mysql:[0-9.]*/mysql:${mysql_correct_version}/g" \
+    -e "s/mysql:[0-9.]*/mysql:${mysql_version}/g" \
     -e "s/mroonga_version=[0-9.]*/mroonga_version=${mroonga_version}/g" \
     -e "s/groonga_version=[0-9.]*/groonga_version=${groonga_version}/g" \
     ${docker_file}
   git add ${docker_file}
 
   ruby "$(dirname "$0")/update-tag-list.rb" \
-       "${mysql_correct_version}" \
+       "${mysql_version}" \
        "${mroonga_version}" \
        "${groonga_version}"
   git add README.md
 
-  tag="mysql-${mysql_correct_version}-${mroonga_version}"
-  message="MySQL ${mysql_correct_version} and Mroonga ${mroonga_version}"
+  tag="mysql-${mysql_version}-${mroonga_version}"
+  message="MySQL ${mysql_version} and Mroonga ${mroonga_version}"
   echo "${message}"
   git commit -m "${message}"
   git tag -a -m "${message}" ${tag}

--- a/update.sh
+++ b/update.sh
@@ -19,16 +19,15 @@ else
 fi
 
 for target_mysql in "${target_mysqls[@]}"; do
+  docker_file="mysql-${target_mysql}/Dockerfile"
   case $target_mysql in
     8.0)
       mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
                         | jq -r '.["8.0"]["version"]')
-      docker_file=mysql-8.0/Dockerfile
       ;;
     8.4)
       mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
                         | jq -r '.["8.4"]["version"]')
-      docker_file=mysql-8.4/Dockerfile
       ;;
   esac
 

--- a/update.sh
+++ b/update.sh
@@ -20,7 +20,6 @@ fi
 
 for target_mysql in "${target_mysqls[@]}"; do
   docker_file="mysql-${target_mysql}/Dockerfile"
-
   mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
                     | jq -r ".[\"${target_mysql}\"][\"version\"]")
 

--- a/update.sh
+++ b/update.sh
@@ -20,16 +20,9 @@ fi
 
 for target_mysql in "${target_mysqls[@]}"; do
   docker_file="mysql-${target_mysql}/Dockerfile"
-  case $target_mysql in
-    8.0)
-      mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
-                        | jq -r '.["8.0"]["version"]')
-      ;;
-    8.4)
-      mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
-                        | jq -r '.["8.4"]["version"]')
-      ;;
-  esac
+    mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
+                      | jq -r ".[\"${target_mysql}\"][\"version\"]")
+
 
   ${SED} \
     -i'' \

--- a/update.sh
+++ b/update.sh
@@ -20,9 +20,9 @@ fi
 
 for target_mysql in "${target_mysqls[@]}"; do
   docker_file="mysql-${target_mysql}/Dockerfile"
-    mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
-                      | jq -r ".[\"${target_mysql}\"][\"version\"]")
 
+  mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
+                    | jq -r ".[\"${target_mysql}\"][\"version\"]")
 
   ${SED} \
     -i'' \

--- a/update.sh
+++ b/update.sh
@@ -48,7 +48,6 @@ for target_mysql in "${target_mysqls[@]}"; do
 
   tag="mysql-${mysql_version}-${mroonga_version}"
   message="MySQL ${mysql_version} and Mroonga ${mroonga_version}"
-  echo "${message}"
   git commit -m "${message}"
   git tag -a -m "${message}" ${tag}
 done

--- a/update.sh
+++ b/update.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 
-set -eu
+set -eux
 
-if [ $# != 3 ]; then
-  echo "Usage: $0 MYSQL_VERSION MROONGA_VERSION GROONGA_VERSION"
-  echo " e.g.: $0 8.0.30 12.06 12.0.6"
+if [ $# != 0 ]; then
+  echo "Usage: $0"
   exit 1
 fi
 
-mysql_version=$1
-mroonga_version=$2
-groonga_version=$3
+target_mysqls=(
+  "8.0"
+  "8.4"
+)
+
+mroonga_version=$(curl https://api.github.com/repos/mroonga/mroonga/releases/latest \
+                    | jq -r '.["tag_name"]' | sed 's/^v//')
+groonga_version=$(curl https://api.github.com/repos/groonga/groonga/releases/latest \
+                    | jq -r '.["tag_name"]' | sed 's/^v//')
 
 if type gsed > /dev/null 2>&1; then
   SED=gsed
@@ -18,25 +23,38 @@ else
   SED=sed
 fi
 
-case $mysql_version in
-  8.0.*)
-    docker_file=mysql-8.0/Dockerfile
-    ;;
-esac
+for target_mysql in "${target_mysqls[@]}"; do
+  case $target_mysql in
+    8.0)
+      mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
+                        | jq -r '.["8.0"]["version"]')
+      docker_file=mysql-8.0/Dockerfile
+      ;;
+    8.4)
+      mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
+                        | jq -r '.["8.4"]["version"]')
+      docker_file=mysql-8.4/Dockerfile
+      ;;
+  esac
 
-${SED} \
-  -i'' \
-  -r \
-  -e "s/mysql:[0-9.]*/mysql:${mysql_version}/g" \
-  -e "s/mroonga_version=[0-9.]*/mroonga_version=${mroonga_version}/g" \
-  -e "s/groonga_version=[0-9.]*/groonga_version=${groonga_version}/g" \
-  ${docker_file}
-git add ${docker_file}
+  ${SED} \
+    -i'' \
+    -r \
+    -e "s/mysql:[0-9.]*/mysql:${mysql_version}/g" \
+    -e "s/mroonga_version=[0-9.]*/mroonga_version=${mroonga_version}/g" \
+    -e "s/groonga_version=[0-9.]*/groonga_version=${groonga_version}/g" \
+    ${docker_file}
+  git add ${docker_file}
 
-ruby "$(dirname "$0")/update-tag-list.rb" "$@"
-git add README.md
+  ruby "$(dirname "$0")/update-tag-list.rb" \
+       "${mysql_version}" \
+       "${mroonga_version}" \
+       "${groonga_version}"
+  git add README.md
 
-tag="mysql-${mysql_version}-${mroonga_version}"
-message="MySQL ${mysql_version} and Mroonga ${mroonga_version}"
-git commit -m "${message}"
-git tag -a -m "${message}" ${tag}
+  tag="mysql-${mysql_version}-${mroonga_version}"
+  message="MySQL ${mysql_version} and Mroonga ${mroonga_version}"
+  echo "${message}"
+  git commit -m "${message}"
+  git tag -a -m "${message}" ${tag}
+done

--- a/update.sh
+++ b/update.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-if [ $# != 0 ]; then
-  echo "Usage: $0"
-  exit 1
-fi
 
 target_mysqls=(
   "8.0"

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -eux
-
 if [ $# != 0 ]; then
   echo "Usage: $0"
   exit 1

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-target_mysqls=(
+target_mysql-versions=(
   "8.0"
   "8.4"
 )
@@ -18,15 +18,15 @@ else
   SED=sed
 fi
 
-for target_mysql in "${target_mysqls[@]}"; do
-  case $target_mysql in
+for target_mysql_version in "${target_mysql-versions[@]}"; do
+  case $target_mysql_version in
     8.0)
-      mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
+      mysql_correct_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
                         | jq -r '.["8.0"]["version"]')
       docker_file=mysql-8.0/Dockerfile
       ;;
     8.4)
-      mysql_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
+      mysql_correct_version=$(curl https://raw.githubusercontent.com/docker-library/mysql/refs/heads/master/versions.json \
                         | jq -r '.["8.4"]["version"]')
       docker_file=mysql-8.4/Dockerfile
       ;;
@@ -35,20 +35,20 @@ for target_mysql in "${target_mysqls[@]}"; do
   ${SED} \
     -i'' \
     -r \
-    -e "s/mysql:[0-9.]*/mysql:${mysql_version}/g" \
+    -e "s/mysql:[0-9.]*/mysql:${mysql_correct_version}/g" \
     -e "s/mroonga_version=[0-9.]*/mroonga_version=${mroonga_version}/g" \
     -e "s/groonga_version=[0-9.]*/groonga_version=${groonga_version}/g" \
     ${docker_file}
   git add ${docker_file}
 
   ruby "$(dirname "$0")/update-tag-list.rb" \
-       "${mysql_version}" \
+       "${mysql_correct_version}" \
        "${mroonga_version}" \
        "${groonga_version}"
   git add README.md
 
-  tag="mysql-${mysql_version}-${mroonga_version}"
-  message="MySQL ${mysql_version} and Mroonga ${mroonga_version}"
+  tag="mysql-${mysql_correct_version}-${mroonga_version}"
+  message="MySQL ${mysql_correct_version} and Mroonga ${mroonga_version}"
   echo "${message}"
   git commit -m "${message}"
   git tag -a -m "${message}" ${tag}


### PR DESCRIPTION
Usage: `./update.sh`

The result of execution of `./update.sh` as below.

```diff
Date:   Thu Jan 30 11:29:55 2025 +0900

    MySQL 8.0.41 and Mroonga 14.13

diff --git a/README.md b/README.md
index 7c5ad8d..2397169 100644
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Currently, groonga/mroonga provides these couples of versions.
 
 | tag                    | MySQL  | Mroonga | Groonga |
 |------------------------|--------|---------|---------|
-| mysql-8.0-latest       | 8.0.40 | 14.12   | 14.1.2  |
+| mysql-8.0-latest       | 8.0.41 | 14.13   | 14.1.3  |
+| mysql-8.0.41-14.13     | 8.0.41 | 14.13   | 14.1.3  |
 | mysql-8.0.40-14.12     | 8.0.40 | 14.12   | 14.1.2  |
 | mysql-8.0.30-12.06     | 8.0.30 | 12.06   | 12.0.6  |
 | mysql-8.0.29-12.04     | 8.0.29 | 12.04   | 12.0.4  |
diff --git a/mysql-8.0/Dockerfile b/mysql-8.0/Dockerfile
index ed6b805..e7fbbec 100644
--- a/mysql-8.0/Dockerfile
+++ b/mysql-8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.0.40-oraclelinux9
+FROM mysql:8.0.41-oraclelinux9
 
 # TODO
 # Remove `--setopt=apache-arrow-almalinux.gpgcheck=0` option.
@@ -8,8 +8,8 @@ FROM mysql:8.0.40-oraclelinux9
 # error: failed to parse public key for /var/cache/yum/metadata/apache-arrow-almalinux-9-x86_64/RPM-GPG-KEY-Apache-Arrow
 # ```
 
-ENV groonga_version=14.1.2 \
-    mroonga_version=14.12
+ENV groonga_version=14.1.3 \
+    mroonga_version=14.13
 
 RUN mkdir -p /etc/mysql/mysql.conf.d && \
     touch /etc/mysql/mysql.conf.d/default-auth-override.cnf && \
@@ -33,6 +33,6 @@ RUN mkdir -p /docker-entrypoint-mroonga-initdb.d && \
       -e 's,docker_process_init_files /,docker_process_init_files /docker-entrypoint-mroonga-initdb.d/* /,g' \
       /usr/local/bin/docker-entrypoint.sh
 
-# mysql:8.0.40 image has DB in /var/lib/mysql/.
+# mysql:8.0.41 image has DB in /var/lib/mysql/.
 # This clears /var/lib/mysql/ to ensure creating a new DB on "docker run".
 VOLUME ["/var/lib/mysql"]
```
