### PR TITLE
ci build: prevent duplicated GitHub Release from being created

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           * Digest: \`${{ steps.docker_build.outputs.digest }}\`
           RELEASE_NOTE
       - name: Create GitHub Release
-        if: github.ref_type == 'tag' && env.PUSH == 'true'
+        if: github.ref_type == 'tag' && startsWith(github.ref_name, matrix.id)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           * Digest: \`${{ steps.docker_build.outputs.digest }}\`
           RELEASE_NOTE
       - name: Create GitHub Release
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' && env.PUSH == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Problem

The following error happened during release.

```
Run gh release create "${GITHUB_REF_NAME}" \
HTTP 422: Validation Failed (https://api.github.com/repos/mroonga/docker/releases)
Release.tag_name already exists
Error: Process completed with exit code 1.
```

## Cause

The `Create GitHub Release` step only checked
`github.ref_type == 'tag'`, so every matrix entry
(e.g. "mysql-8.0" and "mysql-8.4") tried to publish the release page.

## Solution

We add the condtion that we will create Release page only when the tag matches the workflow's `matrix.id`.